### PR TITLE
Endpoint to respond to an inbound with maintenance message

### DIFF
--- a/scheduler/urls.py
+++ b/scheduler/urls.py
@@ -1,5 +1,9 @@
 from django.urls import re_path
-from .views import ReminderCreate, GetMsisdnTimezoneTurn, GetMsisdnTimezones
+from .views import (
+    ReminderCreate, GetMsisdnTimezoneTurn, GetMsisdnTimezones,
+    MaintenanceErrorResponse
+)
+
 
 urlpatterns = [
     re_path(
@@ -16,5 +20,10 @@ urlpatterns = [
         r"^timezones",
         GetMsisdnTimezones.as_view(),
         name="get-timezones",
+    ),
+    re_path(
+        r"^maintenance_response",
+        MaintenanceErrorResponse.as_view(),
+        name="maintenance-response",
     ),
 ]

--- a/scheduler/views.py
+++ b/scheduler/views.py
@@ -141,3 +141,38 @@ class GetMsisdnTimezones(APIView):
             zones = [get_middle_tz(zones)]
 
         return Response({"success": True, "timezones": zones}, status=200)
+
+class MaintenanceErrorResponse(APIView):
+    def post(self, request, *args, **kwargs):
+        try:
+            recipient_id = request.data['contacts'][0]['wa_id']
+        except KeyError:
+            status = 400
+            message = {"contacts.0.wa_id": ["This field is required."]}
+            return Response(message, status=status)
+
+        content = "placeholder text"
+
+        data = {
+            "preview_url": False,
+            "recipient_type": "individual",
+            "to": recipient_id,
+            "type": "text",
+            "text": {"body": content}
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": "Bearer %s" % settings.TURN_AUTH_TOKEN,
+        }
+
+        s = requests.Session()
+        response = s.post(
+            url=urljoin(settings.TURN_URL, "/v1/messages"),
+            data=json.dumps(data),
+            headers=headers,
+        )
+        # Expecting a 200, raise for errors.
+        response.raise_for_status()
+
+        return Response({"accepted": True}, status=200)


### PR DESCRIPTION
This will allow us to replace the RapidPro url in turn with the reminder scheduler url whenever we need to take Rapidpro down for maintenance. Any inbound message to this endpoint will trigger a response to the user with the maintenance content.
The maintenance content still needs to be finalised and the PR will be updated once it is available.